### PR TITLE
Fix duplicated FONT_SCALE key

### DIFF
--- a/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/datasources/SettingsDataSource.kt
+++ b/fingerprint/src/main/java/com/fingerprintjs/android/fingerprint/datasources/SettingsDataSource.kt
@@ -130,7 +130,7 @@ class SettingsDataSourceImpl(
 
     override fun screenOffTimeout(): String {
         return extractSystemSettingsParam(
-            Settings.System.FONT_SCALE
+            Settings.System.SCREEN_OFF_TIMEOUT
         )
     }
 


### PR DESCRIPTION
The method screenOffTimeout wrongly uses the FONT_SCALE Key.